### PR TITLE
chore(.env.example): add ELEVENLABS_VOICE_ID environment variable to …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ ELEVEN_API_KEY=''
 # JARVIS_MODEL='jarvis:latest' # for local dev and testing of model before pushing to hub
 JARVIS_MODEL='fotiecodes/jarvis:latest' # for usage: uncomment and use this instead if you downloaded model from https://ollama.com/fotiecodes/jarvis
 VISION_MODEL='llava'
+ELEVENLABS_VOICE_ID='add the voice id here'

--- a/modules/Interlocus.py
+++ b/modules/Interlocus.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 ELEVENLABS_API_KEY = os.getenv('ELEVENLABS_API_KEY')
+ELEVENLABS_VOICE_ID = os.getenv('ELEVENLABS_VOICE_ID')
 
 class Interlocus:
     def __init__(self):
@@ -22,7 +23,7 @@ class Interlocus:
         audio = generate(
             api_key=ELEVENLABS_API_KEY,
             text=text,
-            voice="xFjhlCVIoEAjDeZpAmFe",
+            voice=ELEVENLABS_VOICE_ID,
             model="eleven_turbo_v2",
         )
         play(audio)


### PR DESCRIPTION
….env.example file

fix(Interlocus.py): use ELEVENLABS_VOICE_ID environment variable instead of hardcoding voice ID to improve flexibility and maintainability

addressing issue #16 