### PR TITLE
refactor(Interlocus.py): adjust silence and queue thresholds to captu…

### DIFF
--- a/modules/Interlocus.py
+++ b/modules/Interlocus.py
@@ -58,12 +58,12 @@ class Interlocus:
         q = queue.Queue()
         # Initialize VAD (voice activity detector)
         vad = webrtcvad.Vad()
-        # Silence and queue thresholds (in number of blocks)
-        silence_threshold = 16
-        q_threshold = 16
+        # Adjusted thresholds: increased silence threshold and queue threshold to capture full sentences
+        silence_threshold = 40    # increased from 24 (~1.2 sec of silence)
+        q_threshold = 40          # increased from 24
         silence_counter = 0
 
-        # Initialize the Whisper model (using a tiny English model as an example)
+        # Initialize the Whisper model (using a small English model as an example)
         model = Model("small.en",
                       print_realtime=False,
                       print_progress=False,


### PR DESCRIPTION
…re full sentences

The silence threshold and queue threshold in the Interlocus class have been increased from 16 to 40. This change was made to improve the capturing of full sentences by the voice activity detector (VAD). The previous thresholds were not capturing long enough periods of silence, resulting in incomplete sentence detection. By increasing the thresholds, the VAD will be more sensitive to longer pauses and ensure that complete sentences are captured. Additionally, a comment was updated to reflect the usage of a small English model instead of a tiny English model for the Whisper model initialization.